### PR TITLE
Fix for LogOnChange and LogOnMount dependencies

### DIFF
--- a/src/components/LogOnChange.tsx
+++ b/src/components/LogOnChange.tsx
@@ -11,11 +11,11 @@ type Props = {
 };
 
 export const LogOnChange: React.StatelessComponent<Props> = (props: Props) => {
-  const { logEvent, amplitudeInstance } = useAmplitude(undefined, props.instanceName);
+  const { logEvent } = useAmplitude(undefined, props.instanceName);
 
   React.useEffect(() => {
     logEvent(props.eventType, props.eventProperties);
-  }, [props.eventType, props.eventProperties, props.value, amplitudeInstance]);
+  }, [props.value]);
 
   return props.children || (null as any);
 };
@@ -25,5 +25,5 @@ LogOnChange.propTypes = {
   eventProperties: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   eventType: PropTypes.string.isRequired,
   instanceName: PropTypes.string,
-  value: PropTypes.any
+  value: PropTypes.any,
 };

--- a/src/components/LogOnMount.tsx
+++ b/src/components/LogOnMount.tsx
@@ -10,11 +10,11 @@ type Props = {
 };
 
 export const LogOnMount: React.StatelessComponent<Props> = (props: Props) => {
-  const { logEvent, amplitudeInstance } = useAmplitude(undefined, props.instanceName);
+  const { logEvent } = useAmplitude(undefined, props.instanceName);
 
   React.useEffect(() => {
     logEvent(props.eventType, props.eventProperties);
-  }, [props.eventType, props.eventProperties, amplitudeInstance]);
+  }, []);
 
   return props.children || (null as any);
 };
@@ -22,5 +22,5 @@ export const LogOnMount: React.StatelessComponent<Props> = (props: Props) => {
 LogOnMount.propTypes = {
   eventProperties: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   eventType: PropTypes.string.isRequired,
-  instanceName: PropTypes.string
+  instanceName: PropTypes.string,
 };


### PR DESCRIPTION
LogOnMount and LogOnMount was triggering too often.
LogOnMount should only trigger events on mount, whereas LogOnChange should trigger on value change.