### PR TITLE
Memoizes Amplitude's component value prop

### DIFF
--- a/src/components/Amplitude.tsx
+++ b/src/components/Amplitude.tsx
@@ -64,15 +64,22 @@ export function Amplitude(props: Props) {
     [props.userProperties, amplitudeInstance]
   )();
 
-  // If we're not providng any additional properties, just get out of the way and call the component
+  // If we're not providing any additional properties, just get out of the way and call the component
   if (!eventProperties) {
     return typeof props.children === "function" ? props.children({ logEvent, instrument }) : props.children || null;
   }
+  
+  // Memoizes the value prop object to avoid re-renders when eventProperties or amplitudeInstance don't change
+  const value = React.useMemo(
+    () => ({
+      eventProperties: {...eventProperties, ...(props.eventProperties || {})},
+      amplitudeInstance,
+    }),
+    [props.eventProperties, amplitudeInstance]
+  );
 
   return (
-    <AmplitudeContext.Provider
-      value={{ eventProperties: { ...eventProperties, ...(props.eventProperties || {}) }, amplitudeInstance }}
-    >
+    <AmplitudeContext.Provider value={value} >
       {typeof props.children === "function" ? props.children({ logEvent, instrument }) : props.children || null}
     </AmplitudeContext.Provider>
   );


### PR DESCRIPTION
Relates to issue https://github.com/koblas/react-amplitude-hooks/issues/12

# Why

Every time an event was triggered, Amplitude component was creating a new object to pass as the `value` prop down to the `AmplitudeContext.Provider`. That was triggering unnecessary re-renders in all the children of the Amplitude component.

# How

By memoizing the `value` object and watching for changes in its dependencies, we avoid recreating the value object when there are no changes to those dependencies.