### PR TITLE
Add option to pass generic type to `logEvent`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-amplitude-hooks",
-  "version": "0.10.1",
+  "version": "0.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Amplitude.tsx
+++ b/src/components/Amplitude.tsx
@@ -13,7 +13,11 @@ export function useAmplitude(eventProperties: object = {}, instanceName: string 
   const { amplitudeInstance, eventProperties: inheritedProperties } = useAmplitudeContext();
 
   return React.useMemo(() => {
-    function logEvent(eventType: string, eventPropertiesIn: object = {}, callback?: any) {
+    function logEvent<T extends string>(
+      eventType: T,
+      eventPropertiesIn: object = {},
+      callback?: any
+    ) {
       if (!amplitudeInstance) {
         return;
       }


### PR DESCRIPTION
this allows for passing an `Event` type to `logEvent`:


```ts
type EventType = 'add to cart' | 'increase quantity'

...

logEvent<EventType>('add to cart')

```